### PR TITLE
Fix ActiveRecord::Base.sanitize removed in 5.1

### DIFF
--- a/lib/populator/factory.rb
+++ b/lib/populator/factory.rb
@@ -83,7 +83,7 @@ module Populator
 
     def rows_sql_arr
       @records.map do |record|
-        quoted_attributes = record.attribute_values.map { |v| @model_class.sanitize(v) }
+        quoted_attributes = record.attribute_values.map { |v| @model_class.connection.quote(v) }
         "(#{quoted_attributes.join(', ')})"
       end
     end


### PR DESCRIPTION
https://github.com/rails/rails/issues/28947
Related issue: https://github.com/ryanb/populator/issues/30